### PR TITLE
Ajuste en la tabla de totales del pdf, se elimino despacho de la tabla

### DIFF
--- a/service/generador_pdf.go
+++ b/service/generador_pdf.go
@@ -455,7 +455,7 @@ func GenerateInvoicePDF(factura *models.Factura, writer io.Writer) error {
 	startTotalsY := timbreY // Usar la misma Y que el timbre
 	rectX := 130.0
 	rectWidth := 60.0
-	numRows := 5 // Número de filas para los totales
+	numRows := 4 // Número de filas para los totales
 	rowHeightTotals := 7.0
 	rectHeight := float64(numRows) * rowHeightTotals
 
@@ -486,11 +486,11 @@ func GenerateInvoicePDF(factura *models.Factura, writer io.Writer) error {
 	pdf.CellFormat(5, rowHeightTotals, "$", "", 0, "L", false, 0, "")
 	pdf.CellFormat(15, rowHeightTotals, FormatMoneySimple(factura.DescuentoPorc), "", 1, "R", false, 0, "")
 	*/
-	pdf.SetX(rectX)
+	/*pdf.SetX(rectX)
 	pdf.CellFormat(40, rowHeightTotals, "Despacho", "", 0, "L", false, 0, "")
 	pdf.CellFormat(5, rowHeightTotals, "$", "", 0, "L", false, 0, "")
 	pdf.CellFormat(15, rowHeightTotals, FormatMoneySimple(0), "", 1, "R", false, 0, "")
-
+	*/
 	pdf.SetX(rectX)
 	pdf.SetFont("Arial", "B", 10)
 	pdf.CellFormat(40, rowHeightTotals, "Total", "", 0, "L", false, 0, "")


### PR DESCRIPTION
Debido a que no se mostrara el valor de despacho en la factura electronica se elimino el lugar que mostraba el valor de despacho dentro del pdf 